### PR TITLE
fix: memory optimisations

### DIFF
--- a/include/bigint.h
+++ b/include/bigint.h
@@ -45,6 +45,7 @@ public:
 
 	// Division
 	Bigint operator/(Bigint q);
+	Bigint& operator/=(Bigint const&);
 
 	// Modulo
 	long long operator%(long long const&);

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -543,7 +543,7 @@ Bigint Bigint::operator=(const long long& a) {
 int Bigint::operator[](int const& b) {
 	int size = this->digits();
 
-	if (b > size) {
+	if (b >= size) {
 		throw "Number out of bounds";
 	}
 
@@ -559,7 +559,8 @@ int Bigint::operator[](int const& b) {
 
 	int f = b - sizeAtBack;
 
-	std::string part = std::to_string(number.at((int)(f / 9)));
+	std::string part = std::to_string(number.at(number.size() - 2 - (int)(f / 9)));
+
 	if (part.size() < 9) {
 		return part[f % 9 + (9 - part.size())] - '0';
 	}

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -418,11 +418,8 @@ Bigint Bigint::operator/(Bigint q) {
 		return *this;
 	}
 
-	Bigint answer;
-
-	Bigint tmp_quotient, sum_quotient, sub_p, tmpx1;
-
-	bool done_flag = false;
+	Bigint sum_quotient, sub_p, tmpx1;
+	int tmp_quotient;
 
 	Bigint look_up[4] = { q, q * 2, q * 4, q * 8 };
 
@@ -438,9 +435,8 @@ Bigint Bigint::operator/(Bigint q) {
 		int digitsQ = look_up_digits[3];
 
 		if (digitsP - look_up_digits[0] < 0) {
-			answer = sum_quotient;
-			answer.positive = this_sign == q_sign;
-			return answer;
+			sum_quotient.positive = this_sign == q_sign;
+			return sum_quotient;
 		}
 
 		if (digitsP - digitsQ < 0) {
@@ -450,18 +446,16 @@ Bigint Bigint::operator/(Bigint q) {
 			sub_p = getFragment(p, digitsQ);
 		}
 
-
 		for (int i = 3; i >= 0; i--) {
 			if (sub_p >= look_up[i]) {
 				tmpx1 = look_up[i];
 				digitsQ = look_up_digits[i];
-				tmp_quotient = (long long)1 << i;
+				tmp_quotient = 1 << i;
 				break;
 			}
 			else if (i == 0) {
-				answer = sum_quotient;
-				answer.positive = this_sign == q_sign;
-				return answer;
+				sum_quotient.positive = this_sign == q_sign;
+				return sum_quotient;
 			}
 		}
 
@@ -469,16 +463,22 @@ Bigint Bigint::operator/(Bigint q) {
 
 		if (k > 0) {
 			std::string temppp(k, '0');
-			temppp = "1" + temppp;
 
-			sum_quotient = sum_quotient + (tmp_quotient * temppp);
-			tmpx1 = tmpx1 * temppp;
+			sum_quotient = sum_quotient + (std::to_string(tmp_quotient) + temppp);
+			tmpx1 = tmpx1 * ("1" + temppp);
 			p = p - tmpx1;
-		} else {
+		}
+		else {
 			sum_quotient = sum_quotient + tmp_quotient;
 			p = p - tmpx1;
 		}
 	}
+}
+
+Bigint& Bigint::operator/=(Bigint const& q) {
+	*this = *this / q;
+
+	return *this;
 }
 
 long long Bigint::operator%(long long const& divisor) {
@@ -541,7 +541,30 @@ Bigint Bigint::operator=(const long long& a) {
 }
 
 int Bigint::operator[](int const& b) {
-	return this->toString()[b] - '0';
+	int size = this->digits();
+
+	if (b > size) {
+		throw "Number out of bounds";
+	}
+
+	if (b == 0 && number.back() < 10) {
+		return number.back();
+	}
+
+	int sizeAtBack = std::log10(number.back()) + 1;
+
+	if (sizeAtBack > b) {
+		return std::to_string(number.back())[b] - '0';
+	}
+
+	int f = b - sizeAtBack;
+
+	std::string part = std::to_string(number.at((int)(f / 9)));
+	if (part.size() < 9) {
+		return part[f % 9 + (9 - part.size())] - '0';
+	}
+
+	return part[f % 9] - '0';
 }
 
 void Bigint::clear() {

--- a/test/bigintTest.cpp
+++ b/test/bigintTest.cpp
@@ -70,13 +70,11 @@ TEST(MultiplicationTests, MultiplicationTests) {
 	EXPECT_TRUE(Bigint(123) * Bigint(-32) == Bigint(-3936));
 	EXPECT_TRUE(Bigint(-22) * Bigint(82) == Bigint(-1804));
 	EXPECT_TRUE(Bigint(-13) * Bigint(-32) == Bigint(416));
-
 	
 	EXPECT_TRUE(Bigint("342387239127313213") * Bigint("2312074892343") == Bigint("791624939044899694217816428059"));
 
 	EXPECT_TRUE(Bigint(-13) * 0 == Bigint(0));
 	EXPECT_TRUE(Bigint(-13) * Bigint(0) == Bigint(0));
-
 
 	EXPECT_TRUE(Bigint(123) * 32 == Bigint(3936));
 	EXPECT_TRUE(Bigint(123) * -32 == Bigint(-3936));
@@ -102,6 +100,11 @@ TEST(DivisionTests, DivisionTests) {
 			==
 		Bigint("24907111989160678895558821")
 	);
+
+	Bigint a(4113);
+	a /= Bigint(20);
+
+	EXPECT_TRUE(a == 205);
 
 	ASSERT_ANY_THROW(Bigint(123) / 0);
 }
@@ -146,4 +149,10 @@ TEST(Streams, Streams) {
 	EXPECT_TRUE(a == sLine);
 	EXPECT_TRUE(a.toString() == sLine);
 	EXPECT_TRUE(toString(a) == sLine);
+}
+
+TEST(Access, Access) {
+	EXPECT_TRUE(Bigint("304839054389543804382543790782030318932382904234")[13] == 4);
+	EXPECT_TRUE(Bigint("304839054389543804382543790782030318932382904234")[44] == 4);
+	EXPECT_ANY_THROW(Bigint(1234)[4]);
 }


### PR DESCRIPTION
fix:
- memory optimisations for division and access operator ([])

feat:
- /= operator

tests:
- division
- access operator ([])