### PR TITLE
Fix: multiplication(long), digits, segmentLength

### DIFF
--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -304,20 +304,58 @@ Bigint& Bigint::operator*=(long long const& b1) {
 		b1_sign = false;
 	}
 
+	if (b >= 1000000000000000000) {
+		*this = *this * Bigint(b1);
+
+		return *this;
+	}
+
 	positive = b1_sign == positive;
+
+	std::vector<int> answer;
+	answer.reserve(number.size() + 3);
 
 	auto it = number.begin();
 	long long sum = 0;
 
+	int lowB = b % 1000000000;
+	int highB = b / 1000000000;
+
 	while (it != number.end()) {
-		sum += (long long)(*it) * b;
-		*it = (int)(sum % 1000000000);
+		sum += (long long)(*it) * lowB;
+		answer.push_back((int)(sum % 1000000000));
 		sum /= 1000000000;
 		++it;
 	}
 	if (sum != 0) {
-		number.push_back((int)sum);
+		answer.push_back((int)sum);
+		sum = 0;
 	}
+
+	if (highB != 0) {
+		it = number.begin();
+
+		auto ite = answer.begin() + 1;
+
+		while (it != number.end()) {
+			sum += (long long)(*it) * highB;
+			if (ite == answer.end()) {
+				answer.push_back((int)(sum % 1000000000));
+			} else {
+				*ite += (int)(sum % 1000000000);
+			}
+			sum /= 1000000000;
+			++it;
+			++ite;
+		}
+		if (sum != 0) {
+			answer.push_back((int)sum);
+		}
+	}
+
+	answer.shrink_to_fit();
+
+	number = answer;
 
 	return *this;
 }
@@ -336,7 +374,7 @@ int Bigint::digits() const {
 	int segments = number.size();
 
 	if (segments == 0) {
-		return 0;
+		return 1;
 	}
 
 	return 9 * (segments - 1) + segmentLength(number.back());
@@ -588,7 +626,7 @@ Bigint Bigint::clone() {
 
 int Bigint::segmentLength(int segment) {
 	if (segment == 0) {
-		return 0;
+		return 1;
 	}
 
 	return (int)std::log10(segment) + 1;

--- a/test/bigintTest.cpp
+++ b/test/bigintTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <fstream>
+#include <climits>
 
 #include "bigint.h"
 
@@ -36,12 +37,22 @@ TEST(SumationTests, SumationTests) {
 	EXPECT_TRUE(Bigint(22) + -82 == Bigint(-60));
 	EXPECT_TRUE(Bigint(-13) + -32 == Bigint(-45));
 	EXPECT_TRUE(Bigint(-32) + 123 == Bigint(91));
+	EXPECT_TRUE(Bigint(999999999) + Bigint(1) == Bigint(1000000000));
+	EXPECT_TRUE(Bigint(999999999) + 1 == Bigint(1000000000));
 
 	Bigint a(123);
 	a += 30;
 	a += 0;
 	
 	EXPECT_TRUE(a == Bigint(153));
+
+	Bigint b(1);
+
+	b += 999999999;
+
+	
+	EXPECT_TRUE(b == Bigint(1000000000));
+
 }
 
 TEST(SubtractionTests, SubtractionTests) {
@@ -74,6 +85,11 @@ TEST(SubtractionTests, SubtractionTests) {
 
 	EXPECT_TRUE(f == Bigint(-42309420841801));
 
+	Bigint g = 42309420844929;
+	g -= 42309420844924;
+	
+	EXPECT_TRUE(g == Bigint(5));
+
 }
 
 TEST(MultiplicationTests, MultiplicationTests) {
@@ -101,6 +117,9 @@ TEST(MultiplicationTests, MultiplicationTests) {
 	b *= Bigint("92384723897592748924789234389");
 
 	EXPECT_TRUE(b == Bigint("2170876855334063153876652533841878955740519322"));
+
+	EXPECT_TRUE(Bigint(454513) * 54234575622444 == Bigint("24650319669883889772"));
+	EXPECT_TRUE(Bigint(454513) * LLONG_MAX == Bigint("4192142494586974716366991"));
 }
 
 TEST(DivisionTests, DivisionTests) {
@@ -196,4 +215,10 @@ TEST(Access, Access) {
 	EXPECT_TRUE(Bigint("304839054389543804382543790782030318932382904234")[13] == 4);
 	EXPECT_TRUE(Bigint("304839054389543804382543790782030318932382904234")[44] == 4);
 	EXPECT_ANY_THROW(Bigint(1234)[4]);
+}
+
+TEST(Digits, Digits) {
+	EXPECT_TRUE(Bigint().digits() == 1);
+	EXPECT_TRUE(Bigint(0).digits() == 1);
+	EXPECT_TRUE(Bigint(34331231).digits() == 8);
 }


### PR DESCRIPTION
fix:
- multiplication for bigger long (values exceeding 10^9 could cause overflow, values until 10^18 are now parsed properly using the same algorithm, values exceeding it, using Bigint multiplication
- digits, segmentLength value for 0 (should be 1)