### PR TITLE
fix: flip_sign and clone

### DIFF
--- a/include/bigint.h
+++ b/include/bigint.h
@@ -32,32 +32,32 @@ public:
   Bigint(std::string_view string);
 
   // Adding
-  Bigint operator+(Bigint const &right) const;
-  Bigint &operator+=(Bigint const &right);
-  Bigint operator+(int64_t const &value) const;
+  Bigint operator+(const Bigint &right) const;
+  Bigint &operator+=(const Bigint &right);
+  Bigint operator+(const int64_t &value) const;
   Bigint &operator+=(int64_t value);
 
   // Subtraction
-  Bigint operator-(Bigint const &right) const;
-  Bigint &operator-=(Bigint const &right);
-  Bigint operator-(int64_t const &value) const;
+  Bigint operator-(const Bigint &right) const;
+  Bigint &operator-=(const Bigint &right);
+  Bigint operator-(const int64_t &value) const;
   Bigint &operator-=(int64_t value);
 
   // Unary minus
   Bigint operator-();
 
   // Multiplication
-  Bigint operator*(Bigint const &right) const;
-  Bigint &operator*=(Bigint const &right);
+  Bigint operator*(const Bigint &right) const;
+  Bigint &operator*=(const Bigint &right);
   Bigint operator*(int64_t value) const;
-  Bigint &operator*=(int64_t const &value);
+  Bigint &operator*=(const int64_t &value);
 
   // Division
   Bigint operator/(Bigint right);
-  Bigint &operator/=(Bigint const &right);
+  Bigint &operator/=(const Bigint &right);
 
   // Modulo
-  [[nodiscard]] int64_t operator%(int64_t const &value) const;
+  [[nodiscard]] int64_t operator%(const int64_t &value) const;
 
   // Comparison
   [[nodiscard]] bool operator<(const Bigint &other) const;
@@ -73,11 +73,11 @@ public:
   Bigint &operator=(Bigint &&other) = default;
 
   // Access
-  [[nodiscard]] int32_t operator[](int32_t const &which) const;
+  [[nodiscard]] int32_t operator[](const int32_t &which) const;
 
   // Input & Output
   friend std::istream &operator>>(std::istream &stream, Bigint &bigint);
-  friend std::ostream &operator<<(std::ostream &stream, Bigint const &bigint);
+  friend std::ostream &operator<<(std::ostream &stream, const Bigint &bigint);
 
   // Helpers
   void clear();
@@ -86,22 +86,22 @@ public:
   [[nodiscard]] int32_t digits() const;
   [[nodiscard]] bool is_even() const;
   [[nodiscard]] bool is_negative() const;
-  Bigint clone();
-  constexpr void flip_sign() const;
+  Bigint clone() const;
+  void flip_sign() const;
 
   Bigint &add_zeroes(uint32_t amount);
 
   // Power
-  Bigint &pow(uint32_t const &power);
+  Bigint &pow(const uint32_t &power);
 
+  [[nodiscard]] int8_t compare(const Bigint &right) const;// 0 a == b, -1 a < b, 1 a > b
 private:
   [[nodiscard]] constexpr static int32_t segment_length(int32_t segment);
-  [[nodiscard]] Bigint pow(uint32_t const &power, std::map<int32_t, Bigint> *lookup);
-  [[nodiscard]] int8_t compare(Bigint const &right) const;// 0 a == b, -1 a < b, 1 a > b
+  [[nodiscard]] Bigint pow(const uint32_t &power, std::map<int32_t, Bigint> *lookup);
   [[nodiscard]] static Bigint get_fragment(const Bigint &bigint, int32_t which);
 };
 
-std::string to_string(Bigint const &bigint);
+std::string to_string(const Bigint &bigint);
 
 }// namespace BigMath
 

--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -35,10 +35,9 @@ Bigint::Bigint(std::string_view string) {
     int32_t num = 0;
 
     for (int32_t idx = size - 1; idx >= 0 && idx >= size - 9; --idx) {
-      if (string[idx] < '0' || string[idx] > '9') {
-        break;
+      if (string[idx] >= '0' && string[idx] <= '9') {
+        num += (string[idx] - '0') * POW10.at(length);
       }
-      num += (string[idx] - '0') * POW10.at(length);
       ++length;
     }
     number.push_back(num);
@@ -46,14 +45,14 @@ Bigint::Bigint(std::string_view string) {
   }
 }
 
-Bigint Bigint::operator+(Bigint const &right) const {
+Bigint Bigint::operator+(const Bigint &right) const {
   Bigint c = *this;
   c += right;
 
   return c;
 }
 
-Bigint &Bigint::operator+=(Bigint const &right) {
+Bigint &Bigint::operator+=(const Bigint &right) {
   if (positive && !right.positive) {
     right.flip_sign();
 
@@ -95,7 +94,7 @@ Bigint &Bigint::operator+=(Bigint const &right) {
   return *this;
 }
 
-Bigint Bigint::operator+(int64_t const &value) const {
+Bigint Bigint::operator+(const int64_t &value) const {
   Bigint c = *this;
   c += value;
 
@@ -139,14 +138,14 @@ Bigint &Bigint::operator+=(int64_t value) {
   return *this;
 }
 
-Bigint Bigint::operator-(Bigint const &right) const {
+Bigint Bigint::operator-(const Bigint &right) const {
   Bigint c = *this;
   c -= right;
 
   return c;
 }
 
-Bigint &Bigint::operator-=(Bigint const &right) {
+Bigint &Bigint::operator-=(const Bigint &right) {
   if (Bigint() == right) {
     return *this;
   }
@@ -194,7 +193,7 @@ Bigint &Bigint::operator-=(Bigint const &right) {
   return *this;
 }
 
-Bigint Bigint::operator-(int64_t const &value) const {
+Bigint Bigint::operator-(const int64_t &value) const {
   Bigint c = *this;
   c -= value;
 
@@ -248,7 +247,7 @@ Bigint Bigint::operator-() {
   return *this;
 }
 
-Bigint Bigint::operator*(Bigint const &right) const {
+Bigint Bigint::operator*(const Bigint &right) const {
   if (right.number.size() == 1) {
     Bigint left = *this;
     left *= right.positive ? right.number[0] : -right.number[0];
@@ -288,7 +287,7 @@ Bigint Bigint::operator*(Bigint const &right) const {
   return result;
 }
 
-Bigint &Bigint::operator*=(Bigint const &right) {
+Bigint &Bigint::operator*=(const Bigint &right) {
   *this = *this * right;
 
   return *this;
@@ -301,7 +300,7 @@ Bigint Bigint::operator*(int64_t value) const {
   return c;
 }
 
-Bigint &Bigint::operator*=(int64_t const &value) {
+Bigint &Bigint::operator*=(const int64_t &value) {
   if (value == 0) {
     clear();
 
@@ -369,7 +368,7 @@ Bigint &Bigint::operator*=(int64_t const &value) {
   return *this;
 }
 
-Bigint &Bigint::pow(uint32_t const &power) {
+Bigint &Bigint::pow(const uint32_t &power) {
   std::map<int32_t, Bigint> lookup;
   if (power % 2 == 0 && !positive) {
     positive = true;
@@ -522,13 +521,13 @@ Bigint Bigint::operator/(Bigint right) {
   }
 }
 
-Bigint &Bigint::operator/=(Bigint const &right) {
+Bigint &Bigint::operator/=(const Bigint &right) {
   *this = *this / right;
 
   return *this;
 }
 
-int64_t Bigint::operator%(int64_t const &value) const {
+int64_t Bigint::operator%(const int64_t &value) const {
   if (number.empty()) {
     return 0;
   }
@@ -578,7 +577,7 @@ Bigint &Bigint::operator=(const std::string &string) {
   return *this;
 }
 
-int32_t Bigint::operator[](int32_t const &which) const {
+int32_t Bigint::operator[](const int32_t &which) const {
   const int32_t size = digits();
 
   if (which >= size) {
@@ -625,7 +624,7 @@ std::string Bigint::to_string() const {
   return stream.str();
 }
 
-Bigint Bigint::clone() {
+Bigint Bigint::clone() const {
   return Bigint(*this);
 }
 
@@ -646,7 +645,7 @@ std::istream &operator>>(std::istream &stream, Bigint &bigint) {
   return stream;
 }
 
-std::ostream &operator<<(std::ostream &stream, Bigint const &bigint) {
+std::ostream &operator<<(std::ostream &stream, const Bigint &bigint) {
   if (bigint.number.empty()) {
     return stream << '0';
   }
@@ -677,7 +676,7 @@ std::ostream &operator<<(std::ostream &stream, Bigint const &bigint) {
   return stream;
 }
 
-Bigint Bigint::pow(uint32_t const &power, std::map<int32_t, Bigint> *lookup) {
+Bigint Bigint::pow(const uint32_t &power, std::map<int32_t, Bigint> *lookup) {
   if (power == 1) {
     return *this;
   }
@@ -754,7 +753,7 @@ int8_t Bigint::compare(const Bigint &right) const {
   return 0;
 }
 
-constexpr void Bigint::flip_sign() const {
+void Bigint::flip_sign() const {
   positive = !positive;
 }
 
@@ -788,7 +787,7 @@ Bigint &Bigint::add_zeroes(uint32_t amount) {
   return *this;
 }
 
-std::string to_string(Bigint const &bigint) {
+std::string to_string(const Bigint &bigint) {
   std::ostringstream stream;
   stream << bigint;
 


### PR DESCRIPTION
feature:
- parsing string now omits illigal characters - this allows for further extensions

API:
- `compare` function is now public - it should improve performance in comparison if multiple conditions are to be checked

fix:
- `clone` supports `const Bigint`
- `flip_sign` shouldn't be `constexpr`

style:
- use `const T` instead of `T const`

breaking change:
- parsing string now omits illigal characters instread of breaking on first illigal character:
```
old: Bigint("123b123") -> 123
new: Bigint("123b123") -> 123123
```